### PR TITLE
mpgs/PanResponderUpdate: Update value to implicitly return false

### DIFF
--- a/src/carousel.js
+++ b/src/carousel.js
@@ -68,7 +68,7 @@ export default class SideSwipe extends Component<CarouselProps, State> {
     };
 
     this.panResponder = PanResponder.create({
-      onStartShouldSetPanResponder: this.handleGestureCapture,
+      onStartShouldSetPanResponder: () => false,
       onMoveShouldSetPanResponder: this.handleGestureCapture,
       onPanResponderGrant: this.handleGestureStart,
       onPanResponderMove: this.handleGestureMove,


### PR DESCRIPTION
Adjusted value for onStartShouldSetPanResponder to implicitly return false, as setting it to handleGestureStart would occasionally allow swiping

### What did you do:
<!-- If not covered in the title or related issue -->



### Does this relate to any issue(s)? If so which one(s)?
<!-- Add issue link here, can just do `#<issue_number>` -->



### Screenshots:
<!-- Add SCREENSHOTS/GIFS here if visuals needed -->



### Checklist:
<!-- Go over all the following points, before creating a PR -->


- [ ] I added link to related issue if there is one
- [ ] I added a screenshot/gif (if appropriate)
- [ ] I ran `yarn lint` and `yarn flow`