### PR TITLE
mpgs/disableGesture: Added page prop, which will disable gestures for screens that aren't AddFunds

### DIFF
--- a/src/carousel.js
+++ b/src/carousel.js
@@ -69,7 +69,7 @@ export default class SideSwipe extends Component<CarouselProps, State> {
 
     this.panResponder = PanResponder.create({
       onStartShouldSetPanResponder: () => false,
-      onMoveShouldSetPanResponder: this.handleGestureCapture,
+      onMoveShouldSetPanResponder: () => this.props.page === 'addFunds' ? this.handleGestureCapture : false,
       onPanResponderGrant: this.handleGestureStart,
       onPanResponderMove: this.handleGestureMove,
       onPanResponderRelease: this.handleGestureRelease,


### PR DESCRIPTION


### What did you do:
Added ternary to disable gestures when the page prop is not equal to 'addFunds'.  This allows us to have both interactive sideswipes and completely static sideswipes.



### Does this relate to any issue(s)? If so which one(s)?
<!-- Add issue link here, can just do `#<issue_number>` -->



### Screenshots:
<!-- Add SCREENSHOTS/GIFS here if visuals needed -->



### Checklist:
<!-- Go over all the following points, before creating a PR -->


- [ ] I added link to related issue if there is one
- [ ] I added a screenshot/gif (if appropriate)
- [ ] I ran `yarn lint` and `yarn flow`